### PR TITLE
Add some debug commands

### DIFF
--- a/src/main/java/bigsir/debugutils/DebugUtils.java
+++ b/src/main/java/bigsir/debugutils/DebugUtils.java
@@ -50,6 +50,9 @@ public class DebugUtils implements ModInitializer, GameStartEntrypoint, RecipeEn
 	public static RangeOption namesInRow;
 	public static KeyBinding debugCubes;
 	public static Map<Class<? extends Entity>, List<String>> cubeNameMap = new HashMap<>();
+	public static boolean frozen = false;
+	public static boolean wasFrozen = false;
+	public static int allowedTicks = 0;
 
 	@Override
 	public void beforeGameStart() {
@@ -78,7 +81,10 @@ public class DebugUtils implements ModInitializer, GameStartEntrypoint, RecipeEn
 		ColorHelper.initHSB();
 
         CommandHelper.createCommand(new RenameCommand());
+        CommandHelper.createCommand(new FreezeCommand());
+        CommandHelper.createCommand(new KillAllCommand());
         CommandHelper.createCommand(new RandTickCommand());
+        CommandHelper.createCommand(new EntityListCommand());
         CommandHelper.createCommand(new TriggerEventCommand());
         CommandHelper.createCommand(new NeighborChangeCommand());
 	}

--- a/src/main/java/bigsir/debugutils/DebugUtils.java
+++ b/src/main/java/bigsir/debugutils/DebugUtils.java
@@ -1,5 +1,6 @@
 package bigsir.debugutils;
 
+import bigsir.debugutils.commands.*;
 import bigsir.debugutils.interfaces.INameable;
 import bigsir.debugutils.utils.ColorHelper;
 import net.fabricmc.api.ModInitializer;
@@ -19,6 +20,7 @@ import org.lwjgl.input.Keyboard;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import turniplabs.halplibe.util.GameStartEntrypoint;
+import turniplabs.halplibe.helper.CommandHelper;
 import turniplabs.halplibe.util.RecipeEntrypoint;
 
 import java.lang.reflect.Field;
@@ -75,6 +77,10 @@ public class DebugUtils implements ModInitializer, GameStartEntrypoint, RecipeEn
 		nameInit();
 		ColorHelper.initHSB();
 
+        CommandHelper.createCommand(new RenameCommand());
+        CommandHelper.createCommand(new RandTickCommand());
+        CommandHelper.createCommand(new TriggerEventCommand());
+        CommandHelper.createCommand(new NeighborChangeCommand());
 	}
 
 	@Override

--- a/src/main/java/bigsir/debugutils/commands/EntityListCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/EntityListCommand.java
@@ -1,0 +1,31 @@
+package bigsir.debugutils.commands;
+
+import net.minecraft.core.world.World;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.entity.Entity;
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.CommandError;
+import net.minecraft.core.net.command.CommandSender;
+import net.minecraft.core.net.command.CommandHandler;
+
+public class EntityListCommand extends Command {
+    public EntityListCommand() {
+        super("entitylist", new String[0]);
+    }
+
+    public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
+        World world = sender.getPlayer().world;
+        for (Entity e : world.loadedEntityList) {
+            System.out.println(e);
+        }
+        return true;
+    }
+
+    public boolean opRequired(String[] args) {
+        return false;
+    }
+
+    public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
+        sender.sendMessage("/entitylist");
+    }
+}

--- a/src/main/java/bigsir/debugutils/commands/FreezeCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/FreezeCommand.java
@@ -1,0 +1,59 @@
+package bigsir.debugutils.commands;
+
+import bigsir.debugutils.DebugUtils;
+
+import net.minecraft.core.world.World;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.entity.Entity;
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.CommandError;
+import net.minecraft.core.net.command.CommandSender;
+import net.minecraft.core.net.command.CommandHandler;
+import net.minecraft.core.entity.player.EntityPlayer;
+
+import java.lang.Math;
+
+public class FreezeCommand extends Command {
+    public FreezeCommand() {
+        super("tick", new String[0]);
+    }
+
+    public int parseInteger(String str) {
+        try {
+            return Integer.parseInt(str);
+        } catch (Exception e) {
+            throw new CommandError("Not an int: \"" + str + "\"");
+        }
+    }
+
+    public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
+        if (args.length == 0) {
+            return false;
+        }
+        if (args[0].charAt(0) == 's') {
+            DebugUtils.frozen = !DebugUtils.frozen;
+            DebugUtils.allowedTicks = 0;
+        } else if (args[0].charAt(0) == 'a') {
+            if (!DebugUtils.frozen) {
+                sender.sendMessage("The ticks need to be stopped!");
+                return true;
+            }
+            // The "+ 1" at the end may seem wrong, but renember that the command is being run mid-tick
+            if (args.length == 2) {
+                DebugUtils.allowedTicks = parseInteger(args[1]) + 1;
+            } else {
+                DebugUtils.allowedTicks = Math.max(0, DebugUtils.allowedTicks) + 2;
+            }
+        }
+        return true;
+    }
+
+    public boolean opRequired(String[] args) {
+        return false;
+    }
+
+    public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
+        sender.sendMessage("/tick s");
+        sender.sendMessage("/tick a [amount=1]");
+    }
+}

--- a/src/main/java/bigsir/debugutils/commands/KillAllCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/KillAllCommand.java
@@ -2,14 +2,16 @@ package bigsir.debugutils.commands;
 
 import net.minecraft.core.world.World;
 import net.minecraft.core.block.Block;
+import net.minecraft.core.entity.Entity;
 import net.minecraft.core.net.command.Command;
 import net.minecraft.core.net.command.CommandError;
 import net.minecraft.core.net.command.CommandSender;
 import net.minecraft.core.net.command.CommandHandler;
+import net.minecraft.core.entity.player.EntityPlayer;
 
-public class RandTickCommand extends Command {
-    public RandTickCommand() {
-        super("rtick", new String[0]);
+public class KillAllCommand extends Command {
+    public KillAllCommand() {
+        super("killall", new String[0]);
     }
 
     public int parseInteger(String str) {
@@ -21,23 +23,9 @@ public class RandTickCommand extends Command {
     }
 
     public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
-        int x = parseInteger(args[0]);
-        int y = parseInteger(args[1]);
-        int z = parseInteger(args[2]);
         World world = sender.getPlayer().world;
-        if (args.length != 4) {
-            Block b = world.getBlock(x, y, z);
-            if (b == null) return true;
-            b.updateTick(world, x, y, z, world.rand);
-        } else {
-            int delay = parseInteger(args[3]);
-            if (delay == -1) {
-                Block b = world.getBlock(x, y, z);
-                if (b == null) return true;
-                b.randomDisplayTick(world, x, y, z, world.rand);
-            } else {
-                world.scheduleBlockUpdate(x, y, z, world.getBlockId(x, y, z), delay);
-            }
+        for (Entity e : world.loadedEntityList) {
+            if (!(e instanceof EntityPlayer)) e.remove();
         }
         return true;
     }
@@ -47,6 +35,6 @@ public class RandTickCommand extends Command {
     }
 
     public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
-        sender.sendMessage("/tick <x> <y> <z> [delay, -1 for display mode]");
+        sender.sendMessage("/killall");
     }
 }

--- a/src/main/java/bigsir/debugutils/commands/NeighborChangeCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/NeighborChangeCommand.java
@@ -1,0 +1,42 @@
+package bigsir.debugutils.commands;
+
+import net.minecraft.core.world.World;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.CommandError;
+import net.minecraft.core.net.command.CommandSender;
+import net.minecraft.core.net.command.CommandHandler;
+
+public class NeighborChangeCommand extends Command {
+    public NeighborChangeCommand() {
+        super("neighborchange", new String[0]);
+    }
+
+    public int parseInteger(String str) {
+        try {
+            return Integer.parseInt(str);
+        } catch (Exception e) {
+            throw new CommandError("Not an int: \"" + str + "\"");
+        }
+    }
+
+    public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
+        int x = parseInteger(args[0]);
+        int y = parseInteger(args[1]);
+        int z = parseInteger(args[2]);
+        int id = parseInteger(args[3]);
+        World world = sender.getPlayer().world;
+        Block b = world.getBlock(x, y, z);
+        if (b == null) return true;
+        b.onNeighborBlockChange(world, x, y, z, id);
+        return true;
+    }
+
+    public boolean opRequired(String[] args) {
+        return false;
+    }
+
+    public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
+        sender.sendMessage("/neighborchange <x> <y> <z> <id>");
+    }
+}

--- a/src/main/java/bigsir/debugutils/commands/RandTickCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/RandTickCommand.java
@@ -1,0 +1,52 @@
+package bigsir.debugutils.commands;
+
+import net.minecraft.core.world.World;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.CommandError;
+import net.minecraft.core.net.command.CommandSender;
+import net.minecraft.core.net.command.CommandHandler;
+
+public class RandTickCommand extends Command {
+    public RandTickCommand() {
+        super("tick", new String[0]);
+    }
+
+    public int parseInteger(String str) {
+        try {
+            return Integer.parseInt(str);
+        } catch (Exception e) {
+            throw new CommandError("Not an int: \"" + str + "\"");
+        }
+    }
+
+    public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
+        int x = parseInteger(args[0]);
+        int y = parseInteger(args[1]);
+        int z = parseInteger(args[2]);
+        World world = sender.getPlayer().world;
+        if (args.length != 4) {
+            Block b = world.getBlock(x, y, z);
+            if (b == null) return true;
+            b.updateTick(world, x, y, z, world.rand);
+        } else {
+            int delay = parseInteger(args[3]);
+            if (delay == -1) {
+                Block b = world.getBlock(x, y, z);
+                if (b == null) return true;
+                b.randomDisplayTick(world, x, y, z, world.rand);
+            } else {
+                world.scheduleBlockUpdate(x, y, z, world.getBlockId(x, y, z), delay);
+            }
+        }
+        return true;
+    }
+
+    public boolean opRequired(String[] args) {
+        return false;
+    }
+
+    public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
+        sender.sendMessage("/tick <x> <y> <z> [delay, -1 for display mode]");
+    }
+}

--- a/src/main/java/bigsir/debugutils/commands/RenameCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/RenameCommand.java
@@ -1,0 +1,31 @@
+package bigsir.debugutils.commands;
+
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.CommandSender;
+import net.minecraft.core.net.command.CommandHandler;
+
+public class RenameCommand extends Command {
+    public RenameCommand() {
+        super("rename", new String[0]);
+    }
+
+    public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
+        if (args.length == 0) return false;
+        StringBuilder name = new StringBuilder();
+            for (int i = 0; i < args.length; i++) {
+            if (i > 0)
+                name.append(' ');
+            name.append(args[i]);
+        }
+        sender.getPlayer().getCurrentEquippedItem().setCustomName("" + name);
+        return true;
+    }
+
+    public boolean opRequired(String[] args) {
+        return false;
+    }
+
+    public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
+        sender.sendMessage("/rename <text..>");
+    }
+}

--- a/src/main/java/bigsir/debugutils/commands/TriggerEventCommand.java
+++ b/src/main/java/bigsir/debugutils/commands/TriggerEventCommand.java
@@ -1,0 +1,42 @@
+package bigsir.debugutils.commands;
+
+import net.minecraft.core.world.World;
+import net.minecraft.core.block.Block;
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.CommandError;
+import net.minecraft.core.net.command.CommandSender;
+import net.minecraft.core.net.command.CommandHandler;
+
+public class TriggerEventCommand extends Command {
+    public TriggerEventCommand() {
+        super("trigger", new String[0]);
+    }
+
+    public int parseInteger(String str) {
+        try {
+            return Integer.parseInt(str);
+        } catch (Exception e) {
+            throw new CommandError("Not an int: \"" + str + "\"");
+        }
+    }
+
+    public boolean execute(CommandHandler handler, CommandSender sender, String[] args) {
+        int x = parseInteger(args[0]);
+        int y = parseInteger(args[1]);
+        int z = parseInteger(args[2]);
+        int i = parseInteger(args[3]);
+        World world = sender.getPlayer().world;
+        Block b = world.getBlock(x, y, z);
+        if (b == null) return true;
+        b.triggerEvent(world, x, y, z, i, world.getBlockMetadata(x, y, z));
+        return true;
+    }
+
+    public boolean opRequired(String[] args) {
+        return false;
+    }
+
+    public void sendCommandSyntax(CommandHandler handler, CommandSender sender) {
+        sender.sendMessage("/trigger <x> <y> <z> <index>");
+    }
+}

--- a/src/main/java/bigsir/debugutils/mixins/ItemStackMixin.java
+++ b/src/main/java/bigsir/debugutils/mixins/ItemStackMixin.java
@@ -1,0 +1,66 @@
+package bigsir.debugutils.mixins;
+
+import net.minecraft.core.item.Item;
+import net.minecraft.core.world.World;
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.item.ItemStack;
+import net.minecraft.core.util.helper.Side;
+import net.minecraft.core.net.command.Command;
+import net.minecraft.core.net.command.Commands;
+import net.minecraft.core.net.command.CommandError;
+import net.minecraft.core.entity.player.EntityPlayer;
+import net.minecraft.core.net.command.TextFormatting;
+import net.minecraft.client.entity.player.EntityPlayerSP;
+import net.minecraft.core.net.command.ClientCommandHandler;
+import net.minecraft.core.net.command.ClientPlayerCommandSender;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ItemStack.class, remap = false)
+public abstract class ItemStackMixin {
+    // TODO: Use item on air as well
+    @Inject(method = "useItem", at = @At(value = "HEAD"),  cancellable = true)
+    void useItem(EntityPlayer entityplayer, World world, int blockX, int blockY, int blockZ, Side side, double xPlaced, double yPlaced, CallbackInfoReturnable<Boolean> cir) {
+        ItemStack is = (ItemStack) (Object) this;
+        if (is.getItem() == Item.stick && is.hasCustomName()) {
+            String name = is.getCustomName();
+            if (name.charAt(0) != '/') return;
+            // Run replacements
+            name = name
+                .replace("<x>", "" + blockX)
+                .replace("<y>", "" + blockY)
+                .replace("<z>", "" + blockZ);
+            // Run command
+            runCmd(name, entityplayer);
+            cir.setReturnValue(true);
+        }
+    }
+
+    void runCmd(String name, EntityPlayer player) {
+        ClientPlayerCommandSender sender = new ClientPlayerCommandSender(Minecraft.getMinecraft(Minecraft.class), (EntityPlayerSP) player);
+        ClientCommandHandler handler = Minecraft.getMinecraft(Minecraft.class).commandHandler;
+
+        String[] args = name.substring(1).split(" ");
+        String[] args1 = new String[args.length - 1];
+        System.arraycopy(args, 1, args1, 0, args.length - 1);
+        for (Command command : Commands.commands) {
+            if (command.isName(args[0])) {
+                try {
+                    boolean success = command.execute(handler, sender, args1);
+                    if (!success)
+                        command.sendCommandSyntax(handler, sender);
+                } catch (CommandError e) {
+                    sender.sendMessage(TextFormatting.RED + e.getMessage());
+                } catch (Throwable e) {
+                    e.printStackTrace();
+                    sender.sendMessage(TextFormatting.RED + "Error!");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/bigsir/debugutils/mixins/MinecraftMixin.java
+++ b/src/main/java/bigsir/debugutils/mixins/MinecraftMixin.java
@@ -1,21 +1,50 @@
 package bigsir.debugutils.mixins;
 
+import bigsir.debugutils.DebugUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.input.InputDevice;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import bigsir.debugutils.DebugUtils;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(value = Minecraft.class, remap = false)
 public abstract class MinecraftMixin {
+    @Inject(method = "checkBoundInputs", at = @At(value = "HEAD"), cancellable = true)
+    public void keyBindingCheck(InputDevice currentInputDevice, CallbackInfoReturnable<Boolean> cir){
+        if(DebugUtils.debugCubes.isPressEvent(currentInputDevice)) {
+            DebugUtils.showDebugCubes.toggle();
+            cir.setReturnValue(true);
+        }
+    }
 
-	@Inject(method = "checkBoundInputs", at = @At(value = "HEAD"), cancellable = true)
-	public void keyBindingCheck(InputDevice currentInputDevice, CallbackInfoReturnable<Boolean> cir){
-		if(DebugUtils.debugCubes.isPressEvent(currentInputDevice)) {
-			DebugUtils.showDebugCubes.toggle();
-			cir.setReturnValue(true);
-		}
-	}
+    private static int ticker = 0;
+    private boolean isGameReallyPaused(boolean old, boolean last) {
+        boolean ret = old || (DebugUtils.frozen && DebugUtils.allowedTicks <= 0);
+        if (last && DebugUtils.allowedTicks > 0) {
+            DebugUtils.allowedTicks--;
+        }
+        return ret;
+    }
+
+    @Inject(method = "runTick", at = @At(value = "HEAD"))
+    private void resetTicker(CallbackInfo ci) {
+        ticker = 0;
+    }
+
+    @WrapOperation(method = "runTick", at = @At(value = "FIELD", target = "isGamePaused"), remap = false)
+    private boolean isGamePaused_i0(Minecraft mc, Operation<Boolean> og) {
+        if (!DebugUtils.frozen) return og.call(mc);
+        ticker++;
+        // 1st and 2nd (and maybe 3rd) are fine, the rest need to be changed
+        if (ticker <= 3) return og.call(mc);
+        // On the 5th, tick the player
+        if (ticker == 5) mc.thePlayer.tick();
+        return isGameReallyPaused(og.call(mc), ticker == 8);
+    }
 }

--- a/src/main/resources/debugutils.mixins.json
+++ b/src/main/resources/debugutils.mixins.json
@@ -11,7 +11,8 @@
     "GameSettingsMixin",
     "MinecraftMixin",
     "PolygonMixin",
-    "WorldRendererMixin"
+    "WorldRendererMixin",
+    "ItemStackMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- Allow sticks with command names to run commands when clicked (not mp compatible, and probably shouldn't be)
- - `<x>`, `<y>`, and `<z>` are subbed out for the block pos, so calling a stick `/setblock <x> <y> <z> 124` will set whatever you click to a gold block
- Added `/rename <str...>` for renaming items (useful for binding commands to a stick)
- Added `/tick s(top)` to stop ticking and `/tick a(dvance) [amount=1]` to advance by a certain amount
- - It's a very primitive implementation so far, no fancy stuff like [subtick walking](https://modrinth.com/mod/subtick) (yet?)
- Added `/killall` to kill all entities but the player
- Added `/rtick <x> <y> <z> [delay, -1 for display mode]` for forcing all 3 types of block ticks
- Added `/entitylist` to print all loaded entities
- Added `/trigger` to force a event trigger
- Added `/neighborchange <x> <y> <z> <id>` to force a neighbor update